### PR TITLE
fix: display number and list of languages on homepage

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,3 +5,17 @@ plugins:
   - jekyll-relative-links
 description: CodesHub is made to help students find codes in different languages easily for every usecase.
 author: Diwas Shrestha
+
+languages:
+  - C
+  - Cpp
+  - Csharp
+  - Go
+  - Html
+  - Java
+  - Javascript
+  - PHP
+  - Python
+  - Rust
+  - Typescript
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,16 @@
+---
+layout: default
+title: CodesHub
+---
+
+## Languages supported
+
+**Total languages:** {{ site.languages | size }}
+
+<ul>
+  {% for lang in site.languages %}
+    <li>
+      <a href="/{{ lang | slugify }}/">{{ lang }}</a>
+    </li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
This PR fixes the homepage of CodesHub to properly display the programming languages supported.

Changes made:

Added a languages list in _config.yml as the source of truth for available languages.

Created docs/index.md to render:
Total number of languages dynamically
List of all languages with links to their respective folders

After merging, the homepage will show:
The correct total count of languages
A clickable list of all language folders