### PR TITLE
Fix duplicate light-curve method and restore download error handling

### DIFF
--- a/Python/AstroPhysics.py
+++ b/Python/AstroPhysics.py
@@ -6,10 +6,6 @@ from astropy.timeseries import LombScargle
 import rebound
 
 # 1. TRANSIT METHOD (Light Curve Analysis)
-def analyze_light_curve(target='Kepler-10', mission='Kepler'):
-    try:
-        lc = search_lightcurve(target, mission=mission).download().normalize()
-    except Exception as e:
 def analyze_light_curve(target='Kepler-10', mission='Kepler', height_threshold=0.001):
     """
     Analyze the light curve for transit events.
@@ -21,7 +17,12 @@ def analyze_light_curve(target='Kepler-10', mission='Kepler', height_threshold=0
             Lower values increase sensitivity to shallow transits but may increase false positives.
             Default is 0.001, suitable for typical exoplanet transits.
     """
-    lc = search_lightcurve(target, mission=mission).download().normalize()
+    try:
+        lc = search_lightcurve(target, mission=mission).download().normalize()
+    except Exception as exc:
+        raise RuntimeError(
+            f"Failed to download light curve for {target} using {mission}: {exc}"
+        ) from exc
     time, flux = lc.time.value, lc.flux.value
     
     # Find dips in brightness (transits) using the specified height threshold


### PR DESCRIPTION
## PR Summary
This small PR Fixes the duplicate `analyze_light_curve` definition introduced in the PR #336 by keeping the enhanced signature with `height_threshold` and reinstating a clear exception message when the light curve download fails.